### PR TITLE
feat: initial support for privsep WireGuard interface management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
@@ -176,6 +176,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b50932a01e7ec5c06160492ab660fb19b6bb2a7878030dd6cd68d21df9d4d"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,25 +217,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.15"
+name = "futures"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -220,21 +278,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-task"
-version = "0.3.15"
+name = "futures-sink"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+
+[[package]]
+name = "futures-task"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
@@ -261,6 +329,25 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -323,14 +410,15 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.10"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7728a72c4c7d72665fde02204bcbd93b247721025b222ef78606f14513e0fd03"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -399,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]
@@ -423,9 +511,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+checksum = "ce791b7ca6638aae45be056e068fc756d871eb3b3b10b8efa62d1c9cec616752"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -438,9 +526,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "lock_api"
@@ -473,6 +561,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,12 +592,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ccba0cfe4fdf15982d1674c69b1fd80bad427d293849982668dfe454bd61f2"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7555d6c7164cc913be1ce7f95cbecdabda61eb2ccd89008524af306fb7f5031"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -568,10 +720,13 @@ version = "0.1.0-dev"
 dependencies = [
  "base64",
  "clap",
+ "futures",
  "hyper",
  "hyper-rustls",
  "indoc",
  "ipnet",
+ "nix 0.22.1",
+ "privdrop",
  "rand_core",
  "rustls",
  "serde",
@@ -580,6 +735,8 @@ dependencies = [
  "serde_with",
  "thiserror",
  "tokio",
+ "tokio-serde",
+ "tokio-util",
  "tower",
  "typed-builder",
  "urlencoding",
@@ -589,18 +746,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -618,6 +775,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "privdrop"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd4c2739642e70439d1c0d9545beec45c1e54128739b3cda29bf2c366028c87"
+dependencies = [
+ "libc",
+ "nix 0.19.1",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -657,9 +824,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -832,18 +999,18 @@ checksum = "b46e1121e8180c12ff69a742aabc4f310542b6ccb69f1691689ac17fdf8618aa"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -863,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
@@ -918,9 +1085,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -940,15 +1107,15 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1007,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1022,9 +1189,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1060,6 +1227,35 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bytes",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1224,9 +1420,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "1.3.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "vec_map"
@@ -1279,9 +1475,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+checksum = "b608ecc8f4198fe8680e2ed18eccab5f0cd4caaf3d83516fa5fb2e927fda2586"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1289,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+checksum = "580aa3a91a63d23aac5b6b267e2d13cb4f363e31dce6c352fca4752ae12e479f"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1304,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+checksum = "171ebf0ed9e1458810dfcb31f2e766ad6b3a89dbda42d8901f2b268277e5f09c"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1314,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+checksum = "6c2657dd393f03aa2a659c25c6ae18a13a4048cebd220e147933ea837efc589f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1327,15 +1523,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.74"
+version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.51"
+version = "0.3.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+checksum = "01c70a82d842c9979078c772d4a1344685045f1a5628f677c2b2eab4dd7d2696"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1395,9 +1591,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,34 @@ TODO(fnichol): fill in
 [features]
 default = ["application"]
 
-# Required for building the CLI application. Should be disabled when depending
-# on the crate as a library. For example, to use as a library in a Cargo.toml:
-# `piawg = { version = "...", default-features = false }`
-application = ["clap"]
+# Required for building the CLI application with privilege separation support.
+# Should be disabled when depending on the crate as a library. For example, to
+# use as a library in a Cargo.toml: `piawg = { version = "...",
+# default-features = false }`
+application = ["clap", "privs"]
+
+# Adds simple IPC between a privileged child process which manages the
+# WireGuard interface and configuration writing. Used in the CLI application.
+ipc = ["futures", "tokio-serde", "tokio-util"]
+
+# Allows running the WireGuard interface management to run in a privileged
+# process with a parent process that has dropped privileges. Communication
+# between processes is managed via the `ipc` feature. Used in the CLI
+# application.
+privs = ["checkroot", "privdrop", "ipc"]
+
+# Adds support to check if the process is running with the root user. Used in
+# the CLI application.
+checkroot = ["nix"]
 
 [dependencies]
 base64 = "0.13.0"
-# A CLI-specific dependency
 clap = { version = "3.0.0-beta.2", optional = true }
-hyper = { version = "0.14.10", default-features = false, features = ["http1", "client", "runtime"] }
+futures = { version = "0.3.16", optional = true }
+hyper = { version = "0.14.10", default-features = false, features = ["http1", "http2", "client", "runtime"] }
 hyper-rustls = { version = "0.22.1" }
 ipnet = { version = "2.3.1", features = ["serde"] }
+nix = { version = "0.22.0", optional = true }
 rand_core = { version = "0.5.0", default-features = false }
 rustls = "0.19.1"
 serde = { version = "1.0.126", features = ["derive"] }
@@ -36,10 +52,15 @@ serde_json = "1.0.64"
 serde_with = "1.9.4"
 thiserror = "1.0.26"
 tokio = { version = "1.8.1", features = ["full"] }
+tokio-serde = { version = "0.8.0", features = ["json"], optional = true }
+tokio-util = { version = "0.6.7", features = ["codec"], optional = true }
 tower = { version = "0.4.8", features = ["util"] }
 typed-builder = "0.9.0"
-urlencoding = "1.3.3"
+urlencoding = "2.1.0"
 x25519-dalek = "1.1.1"
+
+[target.'cfg(unix)'.dependencies]
+privdrop = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 indoc = "1.0.3"

--- a/src/bin/piawg/cli.rs
+++ b/src/bin/piawg/cli.rs
@@ -19,6 +19,12 @@ pub(crate) fn parse() -> Args {
     Args::parse()
 }
 
+/// Parse, validate, and return the CLI arguments as a typed struct.
+#[cfg(feature = "ipc")]
+pub(crate) fn parse_wgctl() -> WgctlArgs {
+    Wgctl::parse().into()
+}
+
 /// TODO(fnichol): fill in
 ///
 /// TODO(fnichol): fill in
@@ -26,7 +32,8 @@ pub(crate) fn parse() -> Args {
 /// Project home page: https://github.com/fnichol/piawg
 #[derive(Clap, Debug)]
 #[clap(
-    global_setting(AppSettings::UnifiedHelpMessage),
+    global_setting = AppSettings::ColoredHelp,
+    global_setting = AppSettings::UnifiedHelpMessage,
     max_term_width = 100,
     author = concat!("\nAuthor: ", env!("CARGO_PKG_AUTHORS"), "\n\n"),
     version = env!("CARGO_PKG_VERSION"),
@@ -40,4 +47,26 @@ pub(crate) struct Args {
     /// Multiple -v options increase verbosity. The maximum is 3.
     #[clap(short = 'v', long = "verbose", parse(from_occurrences))]
     pub(crate) verbose: usize,
+}
+
+#[derive(Clap, Debug)]
+#[clap(
+    global_setting = AppSettings::ColoredHelp,
+    global_setting = AppSettings::UnifiedHelpMessage,
+    max_term_width = 100,
+)]
+pub(crate) enum Wgctl {
+    #[clap(name = "__wgctl__")]
+    Wgctl(WgctlArgs),
+}
+
+#[derive(Clap, Debug)]
+pub(crate) struct WgctlArgs {}
+
+impl From<Wgctl> for WgctlArgs {
+    fn from(val: Wgctl) -> Self {
+        match val {
+            Wgctl::Wgctl(val) => val,
+        }
+    }
 }

--- a/src/bin/piawg/main.rs
+++ b/src/bin/piawg/main.rs
@@ -2,49 +2,100 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-use piawg::{
-    pia::WireGuardAPI,
-    wg::{self, WgConfig},
-};
-use tokio::fs::File;
+use std::env::args;
 
 mod cli;
 
 #[tokio::main]
 async fn main() {
-    let args = cli::parse();
-    // In a real application, use the `log` framework or something similar. In this example case,
-    // we'll do this which avoids more dependencies for one call.
-    if args.verbose > 0 {
-        eprintln!("[debug] parsed cli arguments; args={:?}", args);
+    match args().nth(1).as_deref() {
+        #[cfg(feature = "ipc")]
+        Some("__wgctl__") => cmd::wgctl(cli::parse_wgctl()).await,
+        Some(_) | None => cmd::run(cli::parse()).await,
+    }
+}
+
+mod cmd {
+    use piawg::{
+        pia::WireGuardAPI,
+        wg::{self, WgConfig},
+        InterfaceManagerClient,
+    };
+
+    pub(crate) async fn run(args: crate::cli::Args) {
+        // In a real application, use the `log` framework or something similar. In this example
+        // case, we'll do this which avoids more dependencies for one call.
+        if args.verbose > 0 {
+            eprintln!("[debug] parsed cli arguments; args={:?}", args);
+        }
+
+        let username = std::env::var("PIA_USER").expect("PIA_USER is required");
+        let password = std::env::var("PIA_PASS").expect("PIA_USER is required");
+
+        #[cfg(all(unix, feature = "checkroot"))]
+        if !piawg::checkroot::is_root() {
+            panic!("TODO: you must run this program as root");
+        }
+
+        let mut interface_manager = InterfaceManagerClient::start()
+            .await
+            .expect("failed to start interface manager");
+
+        #[cfg(all(unix, feature = "privs", feature = "ipc"))]
+        piawg::privs::privdrop(piawg::privs::PrivDropInfo::new("nobody"))
+            .expect("failed to drop privs");
+
+        let region = WireGuardAPI::get_region("ca_vancouver")
+            .await
+            .expect("failed to get region");
+        dbg!(&region);
+
+        let token = WireGuardAPI::get_token(username, password)
+            .await
+            .expect("failed to get_token");
+        dbg!(&token);
+
+        let (secret_key, public_key) = wg::generate_keypair();
+
+        let api = WireGuardAPI::for_region(&region).expect("failed to create api");
+
+        let akr = api
+            .add_key(&token, &public_key)
+            .await
+            .expect("failed to add key");
+        let config = WgConfig::from(akr, secret_key);
+        dbg!(&config);
+
+        interface_manager
+            .write_wg_config(config)
+            .await
+            .expect("failed to write config");
+        println!("written out: pia.conf");
+
+        interface_manager
+            .wg_interface_up()
+            .await
+            .expect("failed to bring interface up");
+
+        interface_manager
+            .terminate()
+            .await
+            .expect("failed to terminate interface manager");
+
+        dbg!(&api);
+        // let gsr = api
+        //     .get_signature(&token)
+        //     .await
+        //     .expect("failed to get signature");
+        // dbg!(&gsr);
     }
 
-    let username = std::env::var("PIA_USER").expect("PIA_USER is required");
-    let password = std::env::var("PIA_PASS").expect("PIA_USER is required");
-
-    let token = WireGuardAPI::get_token(username, password)
-        .await
-        .expect("failed to get_token");
-    let (secret_key, public_key) = wg::generate_keypair();
-    let api = WireGuardAPI::create(
-        "vancouver406",
-        "162.216.47.234".parse().expect("failed to parse IpAddr"),
-    )
-    .expect("failed to create api");
-    let akr = api
-        .add_key(&token, &public_key)
-        .await
-        .expect("failed to add key");
-    let wg_cfg = WgConfig::from(akr, secret_key);
-
-    let mut file = File::create("pia.conf")
-        .await
-        .expect("failed to create pia.conf");
-    wg_cfg
-        .write(&mut file)
-        .await
-        .expect("failed to write out pia.conf");
-
-    dbg!(&wg_cfg);
-    println!("written out: pia.conf");
+    #[cfg(feature = "ipc")]
+    pub(crate) async fn wgctl(_args: crate::cli::WgctlArgs) {
+        use tokio::io;
+        piawg::ipc::InterfaceManager::new(io::stdin(), io::stdout())
+            .run()
+            .await
+            .expect("manager failed to continue running");
+    }
 }

--- a/src/checkroot.rs
+++ b/src/checkroot.rs
@@ -1,0 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use nix::unistd;
+
+pub fn is_root() -> bool {
+    unistd::geteuid().is_root()
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use base64::write::EncoderWriter;
 use hyper::{
     client::{connect::dns::Name, HttpConnector},

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -1,0 +1,273 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::wg::{WGError, WgConfig, WgQuick};
+use futures::{SinkExt, StreamExt, TryStreamExt};
+use serde::{Deserialize, Serialize};
+use std::{process::Stdio, time::Duration};
+use thiserror::Error;
+use tokio::{
+    io::{AsyncWriteExt, Stdin, Stdout},
+    process::{Child, ChildStdin, ChildStdout, Command},
+    time,
+};
+use tokio_serde::{
+    formats::{Json, SymmetricalJson},
+    Framed, SymmetricallyFramed,
+};
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
+
+const RX_TIMEOUT_SECS: Duration = Duration::from_secs(5);
+const TX_TIMEOUT_SECS: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Error)]
+pub enum IpcError {
+    #[error("ipc wireguard error")]
+    WG(#[from] WGError),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum Request {
+    Start,
+    WriteWgConfig(WgConfig),
+    WgInterfaceUp,
+    WgInterfaceDown,
+    Terminate,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ResponseError {
+    message: String,
+}
+
+impl From<IpcError> for ResponseError {
+    fn from(val: IpcError) -> Self {
+        Self {
+            message: val.to_string(),
+        }
+    }
+}
+#[derive(Debug, Serialize, Deserialize)]
+enum Response {
+    Ready,
+    WriteWgConfig(Result<(), ResponseError>),
+    WgInterfaceUp(Result<(), ResponseError>),
+    WgInterfaceDown(Result<(), ResponseError>),
+    Terminated,
+}
+
+#[derive(Debug)]
+pub struct InterfaceManagerClient {
+    child: Child,
+    rx: Framed<
+        FramedRead<ChildStdout, LengthDelimitedCodec>,
+        Response,
+        Response,
+        Json<Response, Response>,
+    >,
+    tx: Framed<
+        FramedWrite<ChildStdin, LengthDelimitedCodec>,
+        Request,
+        Request,
+        Json<Request, Request>,
+    >,
+}
+
+impl InterfaceManagerClient {
+    pub async fn start() -> Result<Self, Box<dyn std::error::Error>> {
+        let mut child = Command::new(std::env::current_exe()?)
+            .arg("__wgctl__")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()?;
+        let mut rx = {
+            let stdout = child.stdout.take().expect("TODO: fix me");
+            let codec = FramedRead::new(stdout, LengthDelimitedCodec::new());
+            SymmetricallyFramed::new(codec, SymmetricalJson::default())
+        };
+        let mut tx = {
+            let stdin = child.stdin.take().expect("TODO_ fix me");
+            let codec = FramedWrite::new(stdin, LengthDelimitedCodec::new());
+            SymmetricallyFramed::new(codec, SymmetricalJson::default())
+        };
+
+        time::timeout(Duration::from_secs(5), tx.send(Request::Start)).await??;
+        eprintln!("InterfaceManagerClient: sent Request::Start");
+
+        match time::timeout(Duration::from_secs(5), rx.try_next()).await?? {
+            Some(msg) => match msg {
+                Response::Ready => eprintln!("InterfaceManagerClient: get Response::Ready"),
+                invalid => panic!("TODO: invalid message: {:?}", invalid),
+            },
+            None => panic!("TODO: stream closed before first message"),
+        };
+
+        Ok(Self { child, rx, tx })
+    }
+
+    pub async fn write_wg_config(
+        &mut self,
+        config: WgConfig,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match self.send(Request::WriteWgConfig(config)).await? {
+            Response::WriteWgConfig(result) => {
+                result.map_err(|err| panic!("TODO: failed to write config: {:?}", err))
+            }
+            invalid => panic!("TODO: invalid message: {:?}", invalid),
+        }
+    }
+
+    pub async fn wg_interface_up(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        match self.send(Request::WgInterfaceUp).await? {
+            Response::WgInterfaceUp(result) => {
+                result.map_err(|err| panic!("TODO: failed to bring interface up: {:?}", err))
+            }
+            invalid => panic!("TODO: invalid message: {:?}", invalid),
+        }
+    }
+
+    pub async fn wg_interface_down(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        match self.send(Request::WgInterfaceDown).await? {
+            Response::WgInterfaceDown(result) => {
+                result.map_err(|err| panic!("TODO: failed to bring interface down: {:?}", err))
+            }
+            invalid => panic!("TODO: invalid message: {:?}", invalid),
+        }
+    }
+
+    pub async fn terminate(mut self) -> Result<(), Box<dyn std::error::Error>> {
+        match self.send(Request::Terminate).await? {
+            Response::Terminated => (),
+            invalid => panic!("TODO: invalid message: {:?}", invalid),
+        };
+        self.tx.into_inner().into_inner().shutdown().await?;
+        self.child.wait().await?;
+        Ok(())
+    }
+
+    async fn send(&mut self, request: Request) -> Result<Response, Box<dyn std::error::Error>> {
+        time::timeout(TX_TIMEOUT_SECS, self.tx.send(request)).await??;
+        time::timeout(RX_TIMEOUT_SECS, self.rx.try_next())
+            .await??
+            .ok_or_else(|| panic!("TODO: stream closed before reading response message"))
+    }
+}
+
+pub struct InterfaceManager {
+    rx: Framed<FramedRead<Stdin, LengthDelimitedCodec>, Request, Request, Json<Request, Request>>,
+    tx: Framed<
+        FramedWrite<Stdout, LengthDelimitedCodec>,
+        Response,
+        Response,
+        Json<Response, Response>,
+    >,
+}
+
+impl InterfaceManager {
+    pub fn new(stdin: Stdin, stdout: Stdout) -> Self {
+        let rx = {
+            let codec = FramedRead::new(stdin, LengthDelimitedCodec::new());
+            SymmetricallyFramed::new(codec, SymmetricalJson::default())
+        };
+        let tx = {
+            let codec = FramedWrite::new(stdout, LengthDelimitedCodec::new());
+            SymmetricallyFramed::new(codec, SymmetricalJson::default())
+        };
+        Self { rx, tx }
+    }
+
+    pub async fn run(mut self) -> Result<(), Box<dyn std::error::Error>> {
+        match time::timeout(RX_TIMEOUT_SECS, self.rx.try_next()).await?? {
+            Some(msg) => match msg {
+                Request::Start => eprintln!("InterfaceManager: got Request::Start"),
+                invalid => panic!("TODO: invalid message: {:?}", invalid),
+            },
+            None => panic!("TODO: stream closed before reading start message"),
+        };
+        self.send(Response::Ready).await?;
+        eprintln!("InterfaceManager: sent Response::Ready");
+
+        while let Some(item) = time::timeout(RX_TIMEOUT_SECS, self.rx.next()).await? {
+            let request = match item {
+                Ok(request) => request,
+                Err(err) => {
+                    eprintln!("TODO: error rx next item: {:?}", err);
+                    continue;
+                }
+            };
+
+            match request {
+                Request::Start => {
+                    eprintln!("TODO: already started, invalid message");
+                    continue;
+                }
+                Request::WgInterfaceUp => {
+                    let result = match Self::wg_interface_up().await {
+                        Ok(()) => Ok(()),
+                        Err(err) => {
+                            eprintln!("TODO: error bringing up wg interface: {:?}", err);
+                            Err(err.into())
+                        }
+                    };
+                    self.send(Response::WgInterfaceUp(result)).await?
+                }
+                Request::WgInterfaceDown => {
+                    let result = match Self::wg_interface_down().await {
+                        Ok(()) => Ok(()),
+                        Err(err) => {
+                            eprintln!("TODO: error bringing down wg interface: {:?}", err);
+                            Err(err.into())
+                        }
+                    };
+                    self.send(Response::WgInterfaceDown(result)).await?
+                }
+                Request::WriteWgConfig(config) => {
+                    let result = match Self::write_wg_config(&config).await {
+                        Ok(()) => Ok(()),
+                        Err(err) => {
+                            eprintln!("TODO: error writing wg config: {:?}", err);
+                            Err(err.into())
+                        }
+                    };
+                    self.send(Response::WriteWgConfig(result)).await?
+                }
+                Request::Terminate => {
+                    eprintln!("InterfaceManager: shutting down");
+                    self.send(Response::Terminated).await?;
+                    break;
+                }
+            }
+        }
+
+        self.tx.into_inner().into_inner().shutdown().await?;
+        eprintln!("InterfaceManager: shutdown");
+        Ok(())
+    }
+
+    async fn send(&mut self, response: Response) -> Result<(), Box<dyn std::error::Error>> {
+        time::timeout(TX_TIMEOUT_SECS, self.tx.send(response)).await??;
+        Ok(())
+    }
+
+    async fn wg_interface_up() -> Result<(), IpcError> {
+        WgQuick::for_existing_interface(crate::INTERFACE)?
+            .up()
+            .await
+            .map_err(From::from)
+    }
+
+    async fn wg_interface_down() -> Result<(), IpcError> {
+        WgQuick::for_existing_interface(crate::INTERFACE)?
+            .down()
+            .await
+            .map_err(From::from)
+    }
+
+    async fn write_wg_config(config: &WgConfig) -> Result<(), IpcError> {
+        WgQuick::for_interface(crate::INTERFACE, config)
+            .await
+            .map_err(From::from)
+            .map(|_| ())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,21 @@
 #![doc(html_root_url = "https://docs.rs/piawg/0.1.0-dev")]
 //#![deny(missing_docs)]
 
+#[cfg(all(unix, feature = "checkroot"))]
+pub mod checkroot;
 pub(crate) mod http;
+#[cfg(feature = "ipc")]
+pub mod ipc;
+#[cfg(not(feature = "ipc"))]
+mod noipc;
 pub mod pia;
+#[cfg(all(unix, feature = "privs"))]
+pub mod privs;
 pub mod wg;
+
+const INTERFACE: &str = "pia";
+
+#[cfg(feature = "ipc")]
+pub use ipc::InterfaceManagerClient;
+#[cfg(not(feature = "ipc"))]
+pub use noipc::InterfaceManagerClient;

--- a/src/noipc.rs
+++ b/src/noipc.rs
@@ -1,0 +1,43 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use crate::wg::{WgConfig, WgQuick};
+
+#[cfg(not(feature = "ipc"))]
+pub struct InterfaceManagerClient {}
+
+#[cfg(not(feature = "ipc"))]
+impl InterfaceManagerClient {
+    pub async fn start() -> Result<Self, Box<dyn std::error::Error>> {
+        Ok(Self {})
+    }
+
+    pub async fn wg_interface_up(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        WgQuick::for_existing_interface(crate::INTERFACE)?
+            .up()
+            .await
+            .map_err(From::from)
+    }
+
+    pub async fn wg_interface_down(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        WgQuick::for_existing_interface(crate::INTERFACE)?
+            .down()
+            .await
+            .map_err(From::from)
+    }
+
+    pub async fn write_wg_config(
+        &mut self,
+        config: WgConfig,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        WgQuick::for_interface(crate::INTERFACE, &config)
+            .await
+            .map_err(From::from)
+            .map(|_| ())
+    }
+
+    pub async fn terminate(self) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}

--- a/src/pia.rs
+++ b/src/pia.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use thiserror::Error;
 
 pub mod client;
@@ -14,14 +18,28 @@ pub enum PIAError {
     AddKeyResponseParse(serde_json::Error),
     #[error("pia addkey status was not okay; status={0}")]
     AddKeyResponseStatus(String),
+    #[error("cannot create pia getsignature request")]
+    GetSignatureRequest(hyper::http::Error),
+    #[error("response for pia getsignature failed")]
+    GetSignatureResponse(hyper::Error),
+    #[error("parsing pia getsignature json response body failed")]
+    GetSignatureResponseParse(serde_json::Error),
     #[error("cannot create pia gettoken request")]
     GetTokenRequest(hyper::http::Error),
     #[error("response for pia gettoken failed")]
     GetTokenResponse(hyper::Error),
     #[error("parsing pia gettoken json response body failed")]
     GetTokenResponseParse(serde_json::Error),
+    #[error("cannot create pia getregions request")]
+    GetWGRegionsRequest(hyper::http::Error),
+    #[error("response for pia getregions failed")]
+    GetWGRegionsResponse(hyper::Error),
+    #[error("parsing pia getregions json response body failed")]
+    GetWGRegionsResponseParse(serde_json::Error),
     #[error("reading response body failed")]
     ReadResponseBody(hyper::Error),
+    #[error("region not found; region_id={0}")]
+    RegionNotFound(String),
     #[error("error parsing pia wireguard api uri")]
     InvalidUri(hyper::http::uri::InvalidUri),
 }

--- a/src/pia/client.rs
+++ b/src/pia/client.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use super::PIAError;
 use crate::{
     http,
@@ -5,29 +9,39 @@ use crate::{
 };
 use hyper::{
     body::{self, Buf},
-    Body, Method, Request, Uri,
+    Body, Method, Request, Uri, Version,
 };
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr};
-use std::{fmt, net::IpAddr, net::SocketAddr};
+use std::{collections::HashMap, fmt, io::BufRead, net::IpAddr, net::SocketAddr};
 
 const GENERATE_TOKEN_URL: &str = "https://privateinternetaccess.com/gtoken/generateToken";
+const GET_REGIONS_URL: &str = "https://serverlist.piaservers.net/vpninfo/servers/v4";
+const API_ADD_KEY_PORT: u16 = 1337;
+const API_GET_SIGNATURE_PORT: u16 = 19999;
 
 const PIA_CA: &[u8] = include_bytes!("ca.rsa.4096.crt");
 
+#[derive(Debug)]
 pub struct WireGuardAPI {
-    uri: Uri,
-    socket_addr: SocketAddr,
+    base_uri: Uri,
+    server: IpAddr,
 }
 
 impl WireGuardAPI {
+    pub fn for_region(region: &Region) -> Result<Self, PIAError> {
+        Self::create(&region.server_cn, region.server_ip)
+    }
+
     pub fn create(hostname: impl AsRef<str>, server: IpAddr) -> Result<Self, PIAError> {
-        let uri = format!("https://{}:1337/addKey", hostname.as_ref())
+        let uri = format!("https://{}", hostname.as_ref())
             .parse()
             .map_err(PIAError::InvalidUri)?;
-        let socket_addr = SocketAddr::new(server, 1337);
 
-        Ok(Self { uri, socket_addr })
+        Ok(Self {
+            base_uri: uri,
+            server,
+        })
     }
 
     pub async fn add_key(
@@ -38,14 +52,16 @@ impl WireGuardAPI {
         let req = Request::builder()
             .method(Method::GET)
             .uri(format!(
-                "{}?pt={}&pubkey={}",
-                self.uri,
+                "{}:{}/addKey?pt={}&pubkey={}",
+                self.base_uri.to_string().trim_end_matches('/'),
+                API_ADD_KEY_PORT,
                 urlencoding::encode(token.as_str()),
                 urlencoding::encode(public_key.as_str()),
             ))
             .body(Body::empty())
             .map_err(PIAError::AddKeyRequest)?;
-        let res = http::https_client_with_custom_sni_and_ca(PIA_CA, self.socket_addr)
+        let socket_addr = SocketAddr::new(self.server, API_ADD_KEY_PORT);
+        let res = http::https_client_with_custom_sni_and_ca(PIA_CA, socket_addr)
             .request(req)
             .await
             .map_err(PIAError::AddKeyResponse)?;
@@ -57,6 +73,38 @@ impl WireGuardAPI {
         if add_key_response.status != "OK" {
             return Err(PIAError::AddKeyResponseStatus(add_key_response.status));
         }
+
+        Ok(add_key_response)
+    }
+
+    pub async fn get_signature(&self, token: &PIAToken) -> Result<serde_json::Value, PIAError> {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(format!(
+                "{}:{}/getSignature?token={}",
+                self.base_uri.to_string().trim_end_matches('/'),
+                API_GET_SIGNATURE_PORT,
+                urlencoding::encode(token.as_str()),
+            ))
+            .version(Version::HTTP_2)
+            .body(Default::default())
+            .map_err(PIAError::GetSignatureRequest)?;
+        // dbg!(token);
+        // dbg!(self);
+        // dbg!(&req);
+        // todo!();
+        let socket_addr = SocketAddr::new(self.server, API_GET_SIGNATURE_PORT);
+        let res = dbg!(
+            http::https_client_with_custom_sni_and_ca(PIA_CA, socket_addr)
+                .request(dbg!(req))
+                .await
+        )
+        .map_err(PIAError::GetSignatureResponse)?;
+        let body = body::aggregate(res)
+            .await
+            .map_err(PIAError::ReadResponseBody)?;
+        let add_key_response: serde_json::Value =
+            serde_json::from_reader(body.reader()).map_err(PIAError::GetSignatureResponseParse)?;
 
         Ok(add_key_response)
     }
@@ -86,6 +134,38 @@ impl WireGuardAPI {
 
         Ok(get_token_response.into())
     }
+
+    pub async fn get_regions() -> Result<Regions, PIAError> {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(GET_REGIONS_URL)
+            .body(Body::empty())
+            .map_err(PIAError::GetWGRegionsRequest)?;
+        let res = http::https_client_native_roots()
+            .request(req)
+            .await
+            .map_err(PIAError::GetWGRegionsResponse)?;
+        let body = body::aggregate(res)
+            .await
+            .map_err(PIAError::ReadResponseBody)?
+            .reader()
+            .lines()
+            .next()
+            .expect("failed to get first line in response")
+            .expect("io error");
+        let get_regions_response: GetRegionsResponse =
+            serde_json::from_str(&body).map_err(PIAError::GetTokenResponseParse)?;
+
+        Ok(get_regions_response.into())
+    }
+
+    pub async fn get_region(id: impl AsRef<str>) -> Result<Region, PIAError> {
+        let mut regions = Self::get_regions().await?;
+        regions
+            .0
+            .remove(id.as_ref())
+            .ok_or_else(|| PIAError::RegionNotFound(id.as_ref().to_string()))
+    }
 }
 
 #[derive(Debug)]
@@ -112,6 +192,106 @@ struct GetTokenResponse {
 impl From<GetTokenResponse> for PIAToken {
     fn from(val: GetTokenResponse) -> Self {
         Self(val.token)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GetRegionsResponseGroup {
+    name: String,
+    ports: Vec<u16>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetRegionsResponseRegionServer {
+    ip: IpAddr,
+    cn: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GetRegionsResponseRegion {
+    id: String,
+    name: String,
+    country: String,
+    auto_region: bool,
+    dns: String,
+    port_forward: bool,
+    geo: bool,
+    servers: HashMap<String, Vec<GetRegionsResponseRegionServer>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct GetRegionsResponse {
+    groups: HashMap<String, Vec<GetRegionsResponseGroup>>,
+    regions: Vec<GetRegionsResponseRegion>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Region {
+    pub id: String,
+    pub name: String,
+    pub country: String,
+    pub auto_region: bool,
+    pub dns: String,
+    pub port_forward: bool,
+    pub geo: bool,
+    pub server_ip: IpAddr,
+    pub server_cn: String,
+}
+
+#[derive(Debug)]
+pub struct Regions(HashMap<String, Region>);
+
+impl Regions {
+    pub fn get(&self, id: impl AsRef<str>) -> Option<&Region> {
+        self.0.get(id.as_ref())
+    }
+
+    pub fn get_regions_in_country<'a>(
+        &'a self,
+        country_id: &'a str,
+    ) -> impl Iterator<Item = &Region> {
+        self.0
+            .values()
+            .filter(move |region| region.country == country_id)
+    }
+}
+
+impl From<GetRegionsResponse> for Regions {
+    fn from(val: GetRegionsResponse) -> Self {
+        let inner: HashMap<_, _> = val
+            .regions
+            .into_iter()
+            .filter_map(|region| {
+                if let Some(server) = region
+                    .servers
+                    .into_iter()
+                    .find(|(key, _)| key == "wg")
+                    .map(|(_, value)| value)
+                    .map(|mut vec| {
+                        vec.reverse();
+                        vec.pop()
+                    })
+                    .flatten()
+                {
+                    let wg_region = Region {
+                        id: region.id.clone(),
+                        name: region.name,
+                        country: region.country,
+                        auto_region: region.auto_region,
+                        dns: region.dns,
+                        port_forward: region.port_forward,
+                        geo: region.geo,
+                        server_ip: server.ip,
+                        server_cn: server.cn,
+                    };
+
+                    Some((region.id, wg_region))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        Self(inner)
     }
 }
 

--- a/src/privs.rs
+++ b/src/privs.rs
@@ -1,0 +1,89 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+use nix::unistd::{Group, User};
+use privdrop::PrivDrop;
+use std::{borrow::Cow, env};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PrivError {
+    #[error("error finding group uid {0}: {1}")]
+    FindGroup(u32, nix::Error),
+    #[error("error finding user {0}: {1}")]
+    FindUser(String, nix::Error),
+    #[error("group id not found and must exist: {0}")]
+    GroupNotFound(u32),
+    #[error("error dropping privileges: {0}")]
+    PrivDrop(#[from] privdrop::PrivDropError),
+    #[error("user not found and must exist: {0}")]
+    UserNotFound(String),
+}
+
+pub struct PrivDropInfo<'a, 'b, 'c> {
+    user_name: Option<&'a str>,
+    group_name: Option<&'b str>,
+    default_user_name: &'c str,
+}
+
+impl<'a, 'b, 'c> PrivDropInfo<'a, 'b, 'c> {
+    pub fn new(default_user_name: &'c str) -> Self {
+        Self {
+            user_name: None,
+            group_name: None,
+            default_user_name,
+        }
+    }
+
+    pub fn user_name(&mut self, user_name: &'a str) -> &mut Self {
+        self.user_name = Some(user_name);
+        self
+    }
+
+    pub fn group_name(&mut self, group_name: &'b str) -> &mut Self {
+        self.group_name = Some(group_name);
+        self
+    }
+}
+
+pub fn privdrop(info: PrivDropInfo<'_, '_, '_>) -> Result<(), PrivError> {
+    let user_name = match info.user_name {
+        Some(user_name) => Cow::from(user_name),
+        None => Cow::from(determine_user(info.default_user_name)),
+    };
+    let group_name = match info.group_name {
+        Some(group_name) => Cow::from(group_name),
+        None => Cow::from(determine_group(&user_name)?),
+    };
+
+    PrivDrop::default()
+        .user(user_name.as_ref())
+        .group(group_name.as_ref())
+        .apply()
+        .map_err(From::from)
+}
+
+fn determine_user(default_user: impl AsRef<str>) -> String {
+    if let Ok(sudo_user) = env::var("SUDO_USER") {
+        if !sudo_user.is_empty() {
+            return sudo_user;
+        }
+    }
+    if let Ok(doas_user) = env::var("DOAS_USER") {
+        if !doas_user.is_empty() {
+            return doas_user;
+        }
+    }
+    return String::from(default_user.as_ref());
+}
+
+fn determine_group(user_name: impl AsRef<str>) -> Result<String, PrivError> {
+    let user = User::from_name(user_name.as_ref())
+        .map_err(|err| PrivError::FindUser(user_name.as_ref().to_string(), err))?
+        .ok_or_else(|| PrivError::UserNotFound(user_name.as_ref().to_string()))?;
+    let group = Group::from_gid(user.gid)
+        .map_err(|err| PrivError::FindGroup(user.gid.as_raw(), err))?
+        .ok_or_else(|| PrivError::GroupNotFound(user.gid.as_raw()))?;
+    Ok(group.name)
+}

--- a/src/wg.rs
+++ b/src/wg.rs
@@ -1,29 +1,55 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use crate::pia::client::AddKeyResponse;
 use base64::encode_config;
 use ipnet::IpNet;
 use rand_core::OsRng;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::{
     convert::Infallible,
+    env,
+    ffi::OsStr,
     fmt,
     net::{IpAddr, SocketAddr},
+    path::{Path, PathBuf},
+    process::Stdio,
     str::FromStr,
 };
 use thiserror::Error;
-use tokio::io::{self, AsyncWrite};
+use tokio::{
+    fs::{self, OpenOptions},
+    io::{self, AsyncWrite},
+    process::Command,
+};
 use typed_builder::TypedBuilder;
 use x25519_dalek::{PublicKey as InnerPublicKey, StaticSecret};
 
+const CONFIG_FILE_PREFIX: &str = "/etc/wireguard";
+
 #[derive(Debug, Error)]
 pub enum WGError {
+    #[error("failed to wait on child process")]
+    ChildFailed,
+    #[error("command failed; exit={0}, stderr=\"{1}\"")]
+    CommandFailed(i32, String),
     #[error("serializing wireguard config failed")]
     ConfigSerialize(serde_ini::ser::Error),
+    #[error("failed to create config file")]
+    ConfigFileCreate(std::io::Error),
     #[error("wireguard config io error")]
     IO(std::io::Error),
+    #[error("program not found on PATH: {0}")]
+    CommandNotFound(String),
+    #[error("wireguard config not found; config_file={0}")]
+    ConfigFileNotFound(PathBuf),
+    #[error("failed to spawn and execute process")]
+    SpawnFailed,
 }
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 pub struct SecretKey(String);
 
 impl fmt::Display for SecretKey {
@@ -38,7 +64,7 @@ impl fmt::Debug for SecretKey {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PublicKey(String);
 
 impl PublicKey {
@@ -61,7 +87,7 @@ impl FromStr for PublicKey {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ServerKey(String);
 
 impl ServerKey {
@@ -95,7 +121,7 @@ pub fn generate_keypair() -> (SecretKey, PublicKey) {
 }
 
 #[skip_serializing_none]
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder)]
 #[serde(rename_all = "PascalCase")]
 pub struct WgConfigInterface {
     address: IpAddr,
@@ -105,7 +131,7 @@ pub struct WgConfigInterface {
     dns: Option<IpAddr>,
 }
 
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder)]
 #[serde(rename_all = "PascalCase")]
 pub struct WgConfigPeer {
     #[builder(default = 25)]
@@ -117,7 +143,7 @@ pub struct WgConfigPeer {
     endpoint: SocketAddr,
 }
 
-#[derive(Debug, Serialize, TypedBuilder)]
+#[derive(Debug, Deserialize, Serialize, TypedBuilder)]
 #[serde(rename_all = "PascalCase")]
 pub struct WgConfig {
     interface: WgConfigInterface,
@@ -154,6 +180,129 @@ impl WgConfig {
             .map_err(WGError::IO)
             .map(|_| ())
     }
+}
+
+pub struct WgQuick {
+    config_file: PathBuf,
+    wg_quick_path: Option<PathBuf>,
+}
+
+impl WgQuick {
+    pub fn for_existing_interface(interface: impl AsRef<str>) -> Result<Self, WGError> {
+        Self::for_existing_config_file(config_file_path_for_interface(interface))
+    }
+
+    pub fn for_existing_config_file(config_file: impl Into<PathBuf>) -> Result<Self, WGError> {
+        let config_file = config_file.into();
+        if !config_file.exists() {
+            return Err(WGError::ConfigFileNotFound(config_file));
+        }
+
+        Ok(Self {
+            config_file,
+            wg_quick_path: None,
+        })
+    }
+
+    pub async fn for_interface(
+        interface: impl AsRef<str>,
+        config: &WgConfig,
+    ) -> Result<Self, WGError> {
+        Self::for_config_file(config_file_path_for_interface(interface), config).await
+    }
+
+    pub async fn for_config_file(
+        config_file: impl Into<PathBuf>,
+        config: &WgConfig,
+    ) -> Result<Self, WGError> {
+        let config_file = config_file.into();
+        fs::create_dir_all(config_file.parent().expect("parent dir should exist"))
+            .await
+            .map_err(WGError::ConfigFileCreate)?;
+        let mut open_options = OpenOptions::new();
+        open_options.write(true).truncate(true).create(true);
+        #[cfg(unix)]
+        open_options.mode(0o600);
+        let mut file = open_options
+            .open(&config_file)
+            .await
+            .map_err(WGError::ConfigFileCreate)?;
+        config.write(&mut file).await?;
+
+        Ok(Self {
+            config_file,
+            wg_quick_path: None,
+        })
+    }
+
+    pub async fn up(&mut self) -> Result<(), WGError> {
+        run(Command::new(self.wg_quick_path()?)
+            .arg("up")
+            .arg(&self.config_file))
+        .await?;
+        Ok(())
+    }
+
+    pub async fn down(&mut self) -> Result<(), WGError> {
+        run(Command::new(self.wg_quick_path()?)
+            .arg("down")
+            .arg(&self.config_file))
+        .await?;
+        Ok(())
+    }
+
+    fn wg_quick_path(&mut self) -> Result<&Path, WGError> {
+        if self.wg_quick_path.is_none() {
+            self.wg_quick_path.replace(find_program("wg-quick")?);
+        }
+
+        Ok(self.wg_quick_path.as_ref().expect("wg_quick_path is set"))
+    }
+}
+
+fn config_file_path_for_interface(interface: impl AsRef<str>) -> PathBuf {
+    Path::new(CONFIG_FILE_PREFIX).join(format!("{}.conf", interface.as_ref()))
+}
+
+fn find_program(program: impl AsRef<OsStr>) -> Result<PathBuf, WGError> {
+    let path = Path::new(program.as_ref());
+
+    if path.is_absolute() {
+        if path.is_file() {
+            Ok(path.to_path_buf())
+        } else {
+            Err(WGError::CommandNotFound(
+                program.as_ref().to_string_lossy().to_string(),
+            ))
+        }
+    } else {
+        env::split_paths(&env::var("PATH").unwrap_or_else(|_| "".to_string()))
+            .map(|path| path.join(program.as_ref()))
+            .find(|candidate| candidate.is_file())
+            .ok_or_else(|| WGError::CommandNotFound(program.as_ref().to_string_lossy().to_string()))
+    }
+}
+
+async fn run(command: &mut Command) -> Result<(), WGError> {
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|_| WGError::SpawnFailed)?
+        .wait_with_output()
+        .await
+        .map_err(|_| WGError::ChildFailed)
+        .and_then(|output| {
+            if output.status.success() {
+                Ok(())
+            } else {
+                Err(WGError::CommandFailed(
+                    output.status.code().unwrap_or(-1),
+                    String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+                ))
+            }
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is still in proof-of-concept/prototype territory as not all error
handling is threaded through, the CLI parsing has not been augmented to
support some optional behavior, many panics still exist, and TODOs
remain.

This change adds IPC support for the CLI application on Unix like and
likely Windows systems (still untested). The main process spawns a child
process which will run with root permissions and performs 3 tasks:

- Writes a WireGuard configuration file for the interace
- Brings the interface up
- Brings the interface down

There is only one interface which is known to the child process so no
arbitrary interfaces can be changed. Only serializes WireGuard
configuration data structures are transmitted so this should not
introduce an arbitrary file writing escalation. Furthermore the target
file locaiton is also known to the child process so arbitrary file
locations cannot be specified. Finally, on Unixlike systems, the
privileges are dropped to a non root user after spawning the child so
the remainder of the program functions without elevated privilges.

The IPC logic exists in an `ipc` Cargo feature, the privilege
seperation/dropping is in a `privs` feature, and a function to check if
the process is running as root is in a `checkroot` feature. By default
the `application` feature includes these all, but it is possible to run
the program without IPC and privilege dropping by only selecting `clap`
for the CLI application.

Signed-off-by: Fletcher Nichol <fnichol@nichol.ca>